### PR TITLE
feat: title-based paper import

### DIFF
--- a/app/cli/main.py
+++ b/app/cli/main.py
@@ -134,7 +134,14 @@ def import_cmd(
 ):
     """Import papers from various sources."""
     from app.core.db import init_db
-    from app.pipelines.importer import import_acl, import_bibtex, import_pdf, import_url, parse_import_spec
+    from app.pipelines.importer import (
+        import_acl,
+        import_bibtex,
+        import_by_title,
+        import_pdf,
+        import_url,
+        parse_import_spec,
+    )
 
     init_db()
 
@@ -168,6 +175,17 @@ def import_cmd(
         typer.echo(
             f"{'Created' if result['created'] else 'Already exists'}: {result['title']} (id={result['item_id']})"
         )
+
+    elif src_type == "title":
+        typer.echo(f"Searching for: {args['query']!r}")
+        result = import_by_title(args["query"])
+        source_label = {"arxiv": "arXiv BibTeX", "s2": "Semantic Scholar", "placeholder": "placeholder (no match)"}.get(
+            result["source"], result["source"]
+        )
+        status = "Created" if result["created"] else "Already exists"
+        typer.echo(f"{status} [{source_label}]: {result['title']} (id={result['item_id']})")
+        if result["source"] == "placeholder":
+            typer.echo("Warning: no Semantic Scholar match found — imported as placeholder.", err=True)
 
     else:
         typer.echo(f"Unknown import type: {src_type}", err=True)

--- a/app/connectors/semantic_scholar.py
+++ b/app/connectors/semantic_scholar.py
@@ -94,6 +94,13 @@ def search_s2_by_title(title: str) -> list[dict]:
         return []
 
 
+def fetch_s2_paper_details(paper_id: str) -> dict | None:
+    """Fetch full paper details from Semantic Scholar by paper ID."""
+    url = f"{S2_API}/paper/{paper_id}"
+    params = {"fields": "title,year,authors,abstract,venue,externalIds,publicationVenue"}
+    return _cached_get(url, params)
+
+
 def _fetch_references(paper_id: str) -> list[dict] | None:
     """Fetch references for a single paper_id. Returns None on miss."""
     url = f"{S2_API}/paper/{paper_id}/references"

--- a/app/pipelines/importer.py
+++ b/app/pipelines/importer.py
@@ -6,13 +6,19 @@ All imports are idempotent.
 
 import logging
 import re
+import unicodedata
 from pathlib import Path
 from typing import Any
 
+import requests
 from sqlalchemy.orm import Session
 
 from app.connectors.acl import fetch_acl_papers
-from app.core.bibtex import parse_author_string, parse_bibtex_file
+from app.connectors.semantic_scholar import (
+    fetch_s2_paper_details,
+    search_s2_by_title,
+)
+from app.core.bibtex import parse_author_string, parse_bibtex_file, parse_bibtex_string
 from app.core.db import get_session, init_db
 from app.core.service import (
     add_item_to_collection,
@@ -175,6 +181,8 @@ def import_url(
             external_ids={"url": url},
         )
         session.commit()
+        item_id = item.id
+        item_title = item.title
     except Exception:
         session.rollback()
         raise
@@ -182,7 +190,7 @@ def import_url(
         if own_session:
             session.close()
 
-    return {"item_id": item.id, "created": created, "title": item.title}
+    return {"item_id": item_id, "created": created, "title": item_title}
 
 
 def import_acl(
@@ -271,6 +279,162 @@ def import_acl(
     }
 
 
+def _title_score(query: str, candidate: str) -> float:
+    """Score similarity between query title and a candidate title (0.0–1.0)."""
+
+    def _normalize(s: str) -> str:
+        s = unicodedata.normalize("NFKD", s)
+        s = "".join(c for c in s if not unicodedata.combining(c))
+        return re.sub(r"[^\w\s]", "", s).lower().strip()
+
+    q = _normalize(query)
+    c = _normalize(candidate)
+    if q == c:
+        return 1.0
+    if q in c or c in q:
+        return 0.8
+    q_words = set(q.split())
+    c_words = set(c.split())
+    if not q_words or not c_words:
+        return 0.0
+    overlap = len(q_words & c_words)
+    return 0.7 * overlap / max(len(q_words), len(c_words))
+
+
+def import_by_title(query: str, session: Session | None = None) -> dict[str, Any]:
+    """Import a paper by title, resolving metadata via Semantic Scholar + arXiv.
+
+    Returns: {"item_id": int, "created": bool, "title": str, "source": str}
+    """
+    own_session = session is None
+    if own_session:
+        init_db()
+        session = get_session()
+
+    try:
+        # 1. Search S2 for candidates
+        candidates = search_s2_by_title(query)
+
+        # 2. Score and pick best match
+        best = None
+        best_score = 0.0
+        for cand in candidates:
+            cand_title = cand.get("title") or ""
+            score = _title_score(query, cand_title)
+            if score > best_score:
+                best_score = score
+                best = cand
+
+        if best and best_score >= 0.8:
+            ext_ids = best.get("externalIds") or {}
+            arxiv_id = ext_ids.get("ArXiv")
+
+            if arxiv_id:
+                # 3a. Fetch arXiv BibTeX for richest metadata
+                bib_url = f"https://arxiv.org/bibtex/{arxiv_id}"
+                try:
+                    resp = requests.get(bib_url, timeout=15)
+                    resp.raise_for_status()
+                    entries = parse_bibtex_string(resp.text)
+                except Exception as e:
+                    logger.warning(f"Failed to fetch arXiv BibTeX for {arxiv_id}: {e}")
+                    entries = []
+
+                if entries:
+                    entry = entries[0]
+                    etype = entry.get("ENTRYTYPE", "article")
+                    title = re.sub(r"[{}]", "", entry.get("title", query).strip())
+                    author_str = entry.get("author", "")
+                    authors = parse_author_string(author_str) if author_str else []
+                    year = None
+                    if "year" in entry:
+                        try:
+                            year = int(entry["year"])
+                        except (ValueError, TypeError):
+                            pass
+                    abstract = re.sub(r"[{}]", "", entry.get("abstract", "")).strip()
+                    url = entry.get("url", f"https://arxiv.org/abs/{arxiv_id}")
+                    bib_key = entry.get("ID", "")
+
+                    raw_lines = [f"@{etype}{{{bib_key},"]
+                    for k, v in sorted(entry.items()):
+                        if k in ("ENTRYTYPE", "ID"):
+                            continue
+                        raw_lines.append(f"  {k} = {{{v}}},")
+                    raw_lines.append("}")
+                    bibtex_raw = "\n".join(raw_lines)
+
+                    item, created = upsert_item(
+                        session,
+                        title=title,
+                        authors=authors,
+                        year=year,
+                        abstract=abstract,
+                        source_url=url,
+                        bibtex_key=bib_key or None,
+                        bibtex_raw=bibtex_raw,
+                        external_ids={"arxiv": arxiv_id},
+                    )
+                    session.commit()
+                    item_id = item.id
+                    item_title = item.title
+                    return {"item_id": item_id, "created": created, "title": item_title, "source": "arxiv"}
+
+            # 3b. No arXiv ID — fetch full S2 details
+            paper_id = best.get("paperId", "")
+            details = fetch_s2_paper_details(paper_id) if paper_id else None
+            if details:
+                title = details.get("title") or query
+                year = details.get("year")
+                abstract = details.get("abstract") or ""
+                venue_obj = details.get("publicationVenue") or {}
+                venue = venue_obj.get("name") or details.get("venue") or None
+                authors_raw = details.get("authors") or []
+                authors = [a.get("name", "") for a in authors_raw if a.get("name")]
+                s2_ext = details.get("externalIds") or {}
+                doi = s2_ext.get("DOI")
+                external_ids = {"s2": paper_id}
+                if doi:
+                    external_ids["doi"] = doi
+            else:
+                title = best.get("title") or query
+                year = best.get("year")
+                abstract = ""
+                venue = None
+                authors_raw = best.get("authors") or []
+                authors = [a.get("name", "") for a in authors_raw if a.get("name")]
+                external_ids = {"s2": paper_id} if paper_id else None
+
+            item, created = upsert_item(
+                session,
+                title=title,
+                authors=authors,
+                year=year,
+                abstract=abstract,
+                venue=venue,
+                external_ids=external_ids,
+            )
+            session.commit()
+            item_id = item.id
+            item_title = item.title
+            return {"item_id": item_id, "created": created, "title": item_title, "source": "s2"}
+
+        # 4. No match — import as placeholder
+        logger.warning(f"No Semantic Scholar match found for title: {query!r} (best score={best_score:.2f})")
+        item, created = upsert_item(session, title=query)
+        session.commit()
+        item_id = item.id
+        item_title = item.title
+        return {"item_id": item_id, "created": created, "title": item_title, "source": "placeholder"}
+
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        if own_session:
+            session.close()
+
+
 def parse_import_spec(spec: str) -> dict[str, Any]:
     """Parse an import spec string like 'acl:2024{main,findings}' or 'bib:/path/file.bib'.
 
@@ -300,5 +464,9 @@ def parse_import_spec(spec: str) -> dict[str, Any]:
     if spec.startswith("url:"):
         url = spec[4:]
         return {"type": "url", "args": {"url": url}}
+
+    # Title: title:Paper Title Here
+    if spec.startswith("title:"):
+        return {"type": "title", "args": {"query": spec[6:]}}
 
     raise ValueError(f"Unknown import spec: {spec}")


### PR DESCRIPTION
## Summary
- Add `title:` import spec so users can do `ri import "title:Paper Title"` without needing an arXiv/ACL ID
- Resolves full metadata via Semantic Scholar + arXiv BibTeX pipeline
- Fix `import_url` `DetachedInstanceError` (saves `item.id`/`item.title` before session closes)

## Changes

### `app/connectors/semantic_scholar.py`
- Add `fetch_s2_paper_details(paper_id)` — fetches title, year, authors, abstract, venue, externalIds

### `app/pipelines/importer.py`
- Fix `import_url` bug: store `item_id`/`item_title` as locals inside the `try` block before `finally` closes session
- Add `_title_score(query, candidate)` — NFKD normalize, lowercase, exact/substring/word-overlap scoring
- Add `import_by_title(query, session=None)`:
  1. Search S2 → score candidates → pick best (threshold 0.8)
  2. Has arXiv ID → fetch `https://arxiv.org/bibtex/{id}` → parse + upsert
  3. No arXiv → `fetch_s2_paper_details()` → upsert with S2 metadata
  4. No match → placeholder with warning
- Add `title:` case to `parse_import_spec()`

### `app/cli/main.py`
- Import `import_by_title`
- Add `elif src_type == "title":` handler with source-label feedback

## Test plan
- [ ] `ri import "title:Attention Is All You Need"` → arXiv source, full metadata
- [ ] `ri import "title:Multi-Criteria Evaluation Framework of Selecting Response-worthy Chats in Live Streaming"` → S2 source
- [ ] Repeat above → "Already exists"
- [ ] `ri import "title:Totally Made Up Paper XYZXYZ"` → placeholder + warning
- [ ] `ri import "url:https://example.com" --title "Test"` → no DetachedInstanceError

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)