### PR TITLE
feat: 文献一覧ページ /papers を追加（追加順・ページネーション）

### DIFF
--- a/app/web/server.py
+++ b/app/web/server.py
@@ -784,6 +784,40 @@ def analytics_page(request: Request):
         session.close()
 
 
+@app.get("/papers", response_class=HTMLResponse)
+def papers_list(request: Request, page: int = Query(1, ge=1), per_page: int = Query(50, ge=1, le=100)):
+    session = get_session()
+    try:
+        total = session.execute(select(func.count(Item.id)).where(Item.status == "active")).scalar()
+        total_pages = max(1, (total + per_page - 1) // per_page)
+        page = min(page, total_pages)
+        offset = (page - 1) * per_page
+        items = (
+            session.execute(
+                select(Item)
+                .where(Item.status == "active")
+                .order_by(Item.created_at.desc(), Item.id.desc())
+                .offset(offset)
+                .limit(per_page)
+            )
+            .scalars()
+            .all()
+        )
+        return templates.TemplateResponse(
+            "papers.html",
+            {
+                "request": request,
+                "items": items,
+                "page": page,
+                "per_page": per_page,
+                "total": total,
+                "total_pages": total_pages,
+            },
+        )
+    finally:
+        session.close()
+
+
 @app.get("/collections", response_class=HTMLResponse)
 def collections_list(request: Request):
     session = get_session()

--- a/app/web/templates/base.html
+++ b/app/web/templates/base.html
@@ -84,6 +84,7 @@
             <a href="/" class="brand">ri</a>
             <a href="/">ホーム</a>
             <a href="/search">検索</a>
+            <a href="/papers">文献一覧</a>
             <a href="/collections">コレクション</a>
             <a href="/inbox">Inbox</a>
             <a href="/watches">Watches</a>

--- a/app/web/templates/home.html
+++ b/app/web/templates/home.html
@@ -30,7 +30,10 @@
 {% endif %}
 
 {% if recent_items %}
-<h2>最近追加された文献</h2>
+<div style="display:flex; align-items:baseline; justify-content:space-between;">
+    <h2>最近追加された文献</h2>
+    <a href="/papers" style="font-size:0.85rem;">すべて見る →</a>
+</div>
 {% for item in recent_items %}
 <div class="card">
     <h3><a href="/item/{{ item.id }}">{{ item.title }}</a></h3>

--- a/app/web/templates/papers.html
+++ b/app/web/templates/papers.html
@@ -1,0 +1,45 @@
+{% extends "base.html" %}
+{% block title %}文献一覧 — Research Intelligence{% endblock %}
+{% block content %}
+<div style="display:flex; align-items:baseline; justify-content:space-between; margin-bottom:1rem;">
+    <h1>文献一覧</h1>
+    <span style="font-size:0.85rem; color:var(--muted);">{{ total }} 件（追加順）</span>
+</div>
+
+{% for item in items %}
+<div class="card">
+    <h3><a href="/item/{{ item.id }}">{{ item.title }}</a></h3>
+    <div class="meta">
+        {{ item.author_names[:3] | join(', ') }}{% if item.author_names|length > 3 %} et al.{% endif %}
+        &middot; {{ item.year or '?' }}
+        &middot; {{ item.venue_instance or item.venue or '' }}
+        <span class="badge">{{ item.type }}</span>
+        <span style="margin-left:0.5rem; color:var(--muted);">追加: {{ item.created_at.strftime('%Y-%m-%d') if item.created_at else '?' }}</span>
+    </div>
+</div>
+{% else %}
+<p style="color:var(--muted);">文献がありません。</p>
+{% endfor %}
+
+{% if total_pages > 1 %}
+<div style="display:flex; gap:0.5rem; align-items:center; margin-top:1.5rem; flex-wrap:wrap;">
+    {% if page > 1 %}
+    <a href="/papers?page={{ page - 1 }}&per_page={{ per_page }}" class="btn btn-secondary">← 前へ</a>
+    {% endif %}
+
+    {% for p in range([1, page - 2]|max, [total_pages + 1, page + 3]|min) %}
+    {% if p == page %}
+    <span class="btn" style="background:var(--fg);">{{ p }}</span>
+    {% else %}
+    <a href="/papers?page={{ p }}&per_page={{ per_page }}" class="btn btn-secondary">{{ p }}</a>
+    {% endif %}
+    {% endfor %}
+
+    {% if page < total_pages %}
+    <a href="/papers?page={{ page + 1 }}&per_page={{ per_page }}" class="btn btn-secondary">次へ →</a>
+    {% endif %}
+
+    <span style="font-size:0.85rem; color:var(--muted);">{{ page }} / {{ total_pages }} ページ</span>
+</div>
+{% endif %}
+{% endblock %}


### PR DESCRIPTION
## Summary
- `GET /papers` エンドポイントを追加。全文献を `created_at DESC` 順（追加順）で 50 件/ページのページネーション付きで表示
- ホームの「最近追加された文献」セクションに「すべて見る →」リンクを追加
- ナビバーに「文献一覧」リンクを追加

## Test plan
- [ ] `/papers` にアクセスして文献が追加順で表示されることを確認
- [ ] ページネーションが正しく機能することを確認
- [ ] ホームの「すべて見る →」リンクが `/papers` に遷移することを確認
- [ ] ナビバーの「文献一覧」リンクが機能することを確認

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)