### PR TITLE
feat: UI 日本語統一・各ページに機能説明を追加

### DIFF
--- a/app/web/server.py
+++ b/app/web/server.py
@@ -34,7 +34,41 @@ def _fromjson(value: str) -> list | dict:
         return []
 
 
+_TYPE_LABELS = {"paper": "論文", "blog": "ブログ", "slide": "スライド", "note": "ノート"}
+_STATUS_LABELS = {
+    "new": "新着",
+    "accepted": "承認済み",
+    "rejected": "却下済み",
+    "done": "完了",
+    "failed": "失敗",
+    "running": "実行中",
+    "pending": "待機中",
+    "merged": "統合済み",
+    "active": "有効",
+}
+_JOB_TYPE_LABELS = {
+    "sync": "同期",
+    "download_pdf": "PDF取得",
+    "index": "インデックス再構築",
+}
+
+
+def _type_label(value: str) -> str:
+    return _TYPE_LABELS.get(value, value)
+
+
+def _status_label(value: str) -> str:
+    return _STATUS_LABELS.get(value, value)
+
+
+def _job_type_label(value: str) -> str:
+    return _JOB_TYPE_LABELS.get(value, value)
+
+
 templates.env.filters["fromjson"] = _fromjson
+templates.env.filters["type_label"] = _type_label
+templates.env.filters["status_label"] = _status_label
+templates.env.filters["job_type_label"] = _job_type_label
 
 if STATIC_DIR.exists():
     app.mount("/static", StaticFiles(directory=str(STATIC_DIR)), name="static")

--- a/app/web/templates/analytics.html
+++ b/app/web/templates/analytics.html
@@ -2,6 +2,10 @@
 {% block title %}分析 — Research Intelligence{% endblock %}
 {% block content %}
 <h1>分析</h1>
+<p class="meta" style="margin-bottom:1rem;">
+    ライブラリに登録した文献の傾向を可視化します。会場別・タグ別の年次分布、頻出キーフレーズ、
+    引用ネットワーク分析（被引用数・PageRank）、トピッククラスタリングなどを確認できます。
+</p>
 
 <h2>クラスタ概要</h2>
 {% if cluster_data and cluster_data.clusters %}

--- a/app/web/templates/base.html
+++ b/app/web/templates/base.html
@@ -85,11 +85,11 @@
             <a href="/">ホーム</a>
             <a href="/search">検索</a>
             <a href="/papers">文献一覧</a>
-            <a href="/inbox">Inbox</a>
-            <a href="/watches">Watches</a>
+            <a href="/inbox">受信トレイ</a>
+            <a href="/watches">監視クエリ</a>
             <a href="/analytics">分析</a>
-            <a href="/jobs">Jobs</a>
-            <a href="/history">履歴</a>
+            <a href="/jobs">ジョブ履歴</a>
+            <a href="/history">閲覧履歴</a>
         </div>
     </nav>
     <main>

--- a/app/web/templates/history.html
+++ b/app/web/templates/history.html
@@ -8,7 +8,7 @@
     <tr style="border-bottom:2px solid var(--border); text-align:left;">
       <th style="padding:0.5rem;">タイトル</th>
       <th style="padding:0.5rem;">著者</th>
-      <th style="padding:0.5rem;">Venue</th>
+      <th style="padding:0.5rem;">会場</th>
       <th style="padding:0.5rem;">閲覧日時</th>
     </tr>
   </thead>

--- a/app/web/templates/home.html
+++ b/app/web/templates/home.html
@@ -2,6 +2,10 @@
 {% block title %}Research Intelligence — ホーム{% endblock %}
 {% block content %}
 <h1>Research Intelligence</h1>
+<p class="meta" style="margin-bottom:1rem;">
+    論文・ブログ・スライドを一元管理するローカル文献管理ツールです。
+    BibTeX・PDF・URL からインポートし、全文検索・タグ管理・引用分析・類似論文推薦などができます。
+</p>
 
 <div class="stats">
     <div class="stat-box">
@@ -27,7 +31,7 @@
         {{ item.author_names[:3] | join(', ') }}{% if item.author_names|length > 3 %} et al.{% endif %}
         &middot; {{ item.year or '?' }}
         &middot; {{ item.venue_instance or item.venue or '' }}
-        <span class="badge">{{ item.type }}</span>
+        <span class="badge">{{ item.type | type_label }}</span>
     </div>
 </div>
 {% endfor %}

--- a/app/web/templates/inbox.html
+++ b/app/web/templates/inbox.html
@@ -1,21 +1,25 @@
 {% extends "base.html" %}
-{% block title %}Inbox — Research Intelligence{% endblock %}
+{% block title %}受信トレイ — Research Intelligence{% endblock %}
 {% block content %}
-<h1>Inbox</h1>
+<h1>受信トレイ</h1>
+<p class="meta" style="margin-bottom:1rem;">
+    監視クエリが自動発見した論文候補の一覧です。内容を確認して「承認」するとライブラリに追加されます。
+    「却下」した論文は候補から除外されます。レコメンド機能を使うと、過去の承認傾向をもとに関連度の高い論文を優先表示できます。
+</p>
 
 <div class="filter-row" style="margin-bottom:1rem; display:flex; gap:0.5rem; align-items:center;">
-    <label>ステータス:</label>
+    <label>表示:</label>
     <a href="/inbox?status=new" class="btn {% if current_status == 'new' %}{% else %}btn-secondary{% endif %}" style="font-size:0.8rem; padding:0.3rem 0.6rem;">新着</a>
-    <a href="/inbox?status=recommended" class="btn {% if current_status == 'recommended' %}{% else %}btn-secondary{% endif %}" style="font-size:0.8rem; padding:0.3rem 0.6rem;">推薦</a>
-    <a href="/inbox?status=auto-accept" class="btn {% if current_status == 'auto-accept' %}{% else %}btn-secondary{% endif %}" style="font-size:0.8rem; padding:0.3rem 0.6rem;">自動承認</a>
+    <a href="/inbox?status=recommended" class="btn {% if current_status == 'recommended' %}{% else %}btn-secondary{% endif %}" style="font-size:0.8rem; padding:0.3rem 0.6rem;">おすすめ</a>
+    <a href="/inbox?status=auto-accept" class="btn {% if current_status == 'auto-accept' %}{% else %}btn-secondary{% endif %}" style="font-size:0.8rem; padding:0.3rem 0.6rem;">自動承認候補</a>
     <a href="/inbox?status=accepted" class="btn btn-secondary" style="font-size:0.8rem; padding:0.3rem 0.6rem;">承認済み</a>
     <a href="/inbox?status=rejected" class="btn btn-secondary" style="font-size:0.8rem; padding:0.3rem 0.6rem;">却下済み</a>
     <a href="/inbox?status=all" class="btn btn-secondary" style="font-size:0.8rem; padding:0.3rem 0.6rem;">すべて</a>
     <form method="post" action="/inbox/recommend" style="margin-left:auto;">
-        <button type="submit" class="btn btn-secondary" style="font-size:0.8rem; padding:0.3rem 0.6rem;">レコメンド実行</button>
+        <button type="submit" class="btn btn-secondary" style="font-size:0.8rem; padding:0.3rem 0.6rem;">おすすめ再計算</button>
     </form>
     <form method="post" action="/inbox/auto-accept">
-        <button type="submit" class="btn btn-secondary" style="font-size:0.8rem; padding:0.3rem 0.6rem;">自動承認評価</button>
+        <button type="submit" class="btn btn-secondary" style="font-size:0.8rem; padding:0.3rem 0.6rem;">自動承認を評価</button>
     </form>
 </div>
 
@@ -25,16 +29,16 @@
     <h3>
         {{ it.title }}
         {% if it.recommended %}
-        <span class="badge" style="background:#28a745; color:white; font-size:0.7em; margin-left:0.3rem;">推薦</span>
+        <span class="badge" style="background:#28a745; color:white; font-size:0.7em; margin-left:0.3rem;">おすすめ</span>
         {% endif %}
     </h3>
     <p class="meta">
         {{ it.source_id_type }}:{{ it.source_id_value }}
-        | 年: {{ it.year or "?" }}
+        | {{ it.year or "?" }}年
         {% if it.venue %}| {{ it.venue }}{% endif %}
-        | ステータス: <span class="badge">{{ it.status }}</span>
+        | <span class="badge">{{ it.status | status_label }}</span>
         {% if it.recommend_score is not none %}
-        | スコア: {{ "%.2f"|format(it.recommend_score) }}
+        | 関連スコア: {{ "%.2f"|format(it.recommend_score) }}
         {% endif %}
     </p>
     {% if it.recommended and it.reasons_json %}
@@ -53,7 +57,7 @@
             {% if it.auto_tags_json and it.auto_tags_json != '[]' %}
             <input type="hidden" name="apply_tags" value="1">
             {% endif %}
-            <button type="submit" style="font-size:0.8rem; padding:0.3rem 0.6rem;">承認</button>
+            <button type="submit" style="font-size:0.8rem; padding:0.3rem 0.6rem;">承認してライブラリへ追加</button>
         </form>
         <form method="post" action="/inbox/{{ it.id }}/reject">
             <button type="submit" class="btn-secondary" style="font-size:0.8rem; padding:0.3rem 0.6rem;">却下</button>
@@ -71,6 +75,6 @@
 </div>
 {% endfor %}
 {% else %}
-<p class="meta">Inbox アイテムがありません（ステータス: {{ current_status }}）。</p>
+<p class="meta">該当する論文候補はありません（表示: {{ current_status | status_label }}）。</p>
 {% endif %}
 {% endblock %}

--- a/app/web/templates/item_detail.html
+++ b/app/web/templates/item_detail.html
@@ -10,8 +10,8 @@
 <div class="meta" style="margin-bottom: 1rem;">
     <strong>著者:</strong> {{ item.author_names | join(', ') or '不明' }}<br>
     <strong>年:</strong> {{ item.year or '?' }}
-    &middot; <strong>Venue:</strong> {{ item.venue_instance or item.venue or '—' }}
-    &middot; <strong>種別:</strong> <span class="badge">{{ item.type }}</span>
+    &middot; <strong>会場:</strong> {{ item.venue_instance or item.venue or '—' }}
+    &middot; <strong>種別:</strong> <span class="badge">{{ item.type | type_label }}</span>
     &middot; <strong>BibTeX Key:</strong> <code>{{ item.bibtex_key or '—' }}</code>
 </div>
 
@@ -93,7 +93,7 @@ function downloadAndExtract() {
 </div>
 
 {% if item.abstract %}
-<h2>Abstract</h2>
+<h2>要旨（Abstract）</h2>
 <div class="abstract">{{ item.abstract }}</div>
 {% endif %}
 
@@ -132,11 +132,11 @@ function copyBibtex() {
 <h2>引用関係</h2>
 <div class="card" style="margin-bottom: 1rem;">
     <div style="display: flex; gap: 1rem; margin-bottom: 1rem;">
-        <button onclick="showTab('refs')" id="tab-refs" style="font-weight:bold; border-bottom: 2px solid #007bff;">References</button>
-        <button onclick="showTab('citedby')" id="tab-citedby">Cited by</button>
-        <button onclick="showTab('similar')" id="tab-similar">Similar</button>
-        <button onclick="showTab('mentions')" id="tab-mentions">Mentioned in Notes</button>
-        <button onclick="showTab('graph')" id="tab-graph">Graph</button>
+        <button onclick="showTab('refs')" id="tab-refs" style="font-weight:bold; border-bottom: 2px solid #007bff;">参考文献</button>
+        <button onclick="showTab('citedby')" id="tab-citedby">被引用</button>
+        <button onclick="showTab('similar')" id="tab-similar">類似論文</button>
+        <button onclick="showTab('mentions')" id="tab-mentions">ノートで言及</button>
+        <button onclick="showTab('graph')" id="tab-graph">引用グラフ</button>
     </div>
 
     <div id="panel-refs">

--- a/app/web/templates/jobs.html
+++ b/app/web/templates/jobs.html
@@ -1,7 +1,11 @@
 {% extends "base.html" %}
-{% block title %}Jobs — Research Intelligence{% endblock %}
+{% block title %}ジョブ履歴 — Research Intelligence{% endblock %}
 {% block content %}
-<h1>Jobs</h1>
+<h1>ジョブ履歴</h1>
+<p class="meta" style="margin-bottom:1rem;">
+    バックグラウンドで実行された同期・PDF取得・インデックス再構築などのタスクの実行記録です。
+    失敗したジョブはエラー内容を確認し、原因を修正してから再実行してください。
+</p>
 
 {% if jobs %}
 <table style="width:100%; border-collapse:collapse; font-size:0.9em;">
@@ -9,10 +13,10 @@
         <tr style="border-bottom:2px solid #ddd;">
             <th style="text-align:left; padding:0.5rem;">ID</th>
             <th style="text-align:left; padding:0.5rem;">種別</th>
-            <th style="text-align:left; padding:0.5rem;">ステータス</th>
-            <th style="text-align:left; padding:0.5rem;">開始</th>
-            <th style="text-align:left; padding:0.5rem;">終了</th>
-            <th style="text-align:left; padding:0.5rem;">時間</th>
+            <th style="text-align:left; padding:0.5rem;">状態</th>
+            <th style="text-align:left; padding:0.5rem;">開始日時</th>
+            <th style="text-align:left; padding:0.5rem;">終了日時</th>
+            <th style="text-align:left; padding:0.5rem;">所要時間</th>
             <th style="text-align:left; padding:0.5rem;">概要</th>
         </tr>
     </thead>
@@ -20,23 +24,23 @@
     {% for job in jobs %}
         <tr style="border-bottom:1px solid #eee;">
             <td style="padding:0.5rem;">{{ job.id }}</td>
-            <td style="padding:0.5rem;"><code>{{ job.job_type }}</code></td>
+            <td style="padding:0.5rem;"><code>{{ job.job_type | job_type_label }}</code></td>
             <td style="padding:0.5rem;">
                 {% if job.status == 'done' %}
-                <span class="badge" style="background:#d1fae5; color:#059669;">{{ job.status }}</span>
+                <span class="badge" style="background:#d1fae5; color:#059669;">{{ job.status | status_label }}</span>
                 {% elif job.status == 'failed' %}
-                <span class="badge" style="background:#fecaca; color:#dc2626;">{{ job.status }}</span>
+                <span class="badge" style="background:#fecaca; color:#dc2626;">{{ job.status | status_label }}</span>
                 {% elif job.status == 'running' %}
-                <span class="badge" style="background:#fef08a; color:#854d0e;">{{ job.status }}</span>
+                <span class="badge" style="background:#fef08a; color:#854d0e;">{{ job.status | status_label }}</span>
                 {% else %}
-                <span class="badge">{{ job.status }}</span>
+                <span class="badge">{{ job.status | status_label }}</span>
                 {% endif %}
             </td>
             <td style="padding:0.5rem;">{{ job.started_at or '—' }}</td>
             <td style="padding:0.5rem;">{{ job.finished_at or '—' }}</td>
             <td style="padding:0.5rem;">
                 {% if job.started_at and job.finished_at %}
-                    {{ (job.finished_at - job.started_at).total_seconds()|round(1) }}s
+                    {{ (job.finished_at - job.started_at).total_seconds()|round(1) }}秒
                 {% else %}
                     —
                 {% endif %}
@@ -55,6 +59,6 @@
     </tbody>
 </table>
 {% else %}
-<p class="meta">ジョブの記録がありません。</p>
+<p class="meta">ジョブの実行記録はまだありません。</p>
 {% endif %}
 {% endblock %}

--- a/app/web/templates/papers.html
+++ b/app/web/templates/papers.html
@@ -13,7 +13,7 @@
         {{ item.author_names[:3] | join(', ') }}{% if item.author_names|length > 3 %} et al.{% endif %}
         &middot; {{ item.year or '?' }}
         &middot; {{ item.venue_instance or item.venue or '' }}
-        <span class="badge">{{ item.type }}</span>
+        <span class="badge">{{ item.type | type_label }}</span>
         <span style="margin-left:0.5rem; color:var(--muted);">追加: {{ item.created_at.strftime('%Y-%m-%d') if item.created_at else '?' }}</span>
     </div>
 </div>

--- a/app/web/templates/search.html
+++ b/app/web/templates/search.html
@@ -15,7 +15,7 @@
         <input type="text" name="author" value="{{ author }}" placeholder="著者名" style="width:140px;">
         <label>年:</label>
         <input type="text" name="year" value="{{ year }}" placeholder="2024 or 2023:2024" style="width:120px;">
-        <label>Venue:</label>
+        <label>会場:</label>
         <input type="text" name="venue" value="{{ venue }}" placeholder="ACL" style="width:100px;">
         <label>タグ:</label>
         <select name="tag">
@@ -27,9 +27,9 @@
         <label>種別:</label>
         <select name="type">
             <option value="">すべて</option>
-            <option value="paper" {% if item_type == 'paper' %}selected{% endif %}>Paper</option>
-            <option value="blog" {% if item_type == 'blog' %}selected{% endif %}>Blog</option>
-            <option value="slide" {% if item_type == 'slide' %}selected{% endif %}>Slide</option>
+            <option value="paper" {% if item_type == 'paper' %}selected{% endif %}>論文</option>
+            <option value="blog" {% if item_type == 'blog' %}selected{% endif %}>ブログ</option>
+            <option value="slide" {% if item_type == 'slide' %}selected{% endif %}>スライド</option>
         </select>
         <label>件数:</label>
         <select name="per_page">
@@ -56,7 +56,7 @@
         {{ item.author_names[:3] | join(', ') }}{% if item.author_names|length > 3 %} et al.{% endif %}
         &middot; {{ item.year or '?' }}
         &middot; {{ item.venue_instance or item.venue or '' }}
-        <span class="badge">{{ item.type }}</span>
+        <span class="badge">{{ item.type | type_label }}</span>
         &middot; スコア: {{ "%.3f"|format(r.score) }}
     </div>
     {% if r.snippet %}

--- a/app/web/templates/watches.html
+++ b/app/web/templates/watches.html
@@ -1,28 +1,33 @@
 {% extends "base.html" %}
-{% block title %}Watch 一覧 — Research Intelligence{% endblock %}
+{% block title %}監視クエリ — Research Intelligence{% endblock %}
 {% block content %}
-<h1>Watch 一覧</h1>
+<h1>監視クエリ</h1>
+<p class="meta" style="margin-bottom:1rem;">
+    キーワードや検索条件を登録しておくと、arXiv・OpenAlex を定期的に検索して新着論文を自動発見します。
+    発見された論文は「受信トレイ」に蓄積され、承認するとライブラリに追加されます。
+    <code>ri watch run</code> コマンドまたは下の「実行」ボタンで手動実行もできます。
+</p>
 
 <div class="card">
-    <h2>Watch を追加</h2>
+    <h2>監視クエリを追加</h2>
     <form method="post" action="/watches" style="display:flex; gap:0.5rem; flex-wrap:wrap; align-items:end;">
         <div>
             <label class="meta">名前</label><br>
             <input type="text" name="name" required placeholder="my-watch">
         </div>
         <div>
-            <label class="meta">ソース</label><br>
+            <label class="meta">検索元</label><br>
             <select name="source">
                 <option value="arxiv">arXiv</option>
                 <option value="openalex">OpenAlex</option>
             </select>
         </div>
         <div>
-            <label class="meta">クエリ</label><br>
+            <label class="meta">検索クエリ</label><br>
             <input type="text" name="query" required placeholder="retrieval augmented generation" style="min-width:250px;">
         </div>
         <div>
-            <label class="meta">カテゴリ (arXiv)</label><br>
+            <label class="meta">カテゴリ（arXiv のみ）</label><br>
             <input type="text" name="category" placeholder="cs.CL">
         </div>
         <button type="submit">追加</button>
@@ -30,16 +35,16 @@
 </div>
 
 {% if watches %}
-<h2>登録済み Watch</h2>
+<h2>登録済みの監視クエリ</h2>
 {% for w in watches %}
 <div class="card" style="display:flex; justify-content:space-between; align-items:center;">
     <div>
         <h3>{{ w.name }}</h3>
         <p class="meta">
-            ソース: <span class="badge">{{ w.source }}</span>
-            クエリ: {{ w.query }}
+            検索元: <span class="badge">{{ w.source }}</span>
+            &middot; クエリ: {{ w.query }}
             {% if w.filters_json %}| フィルター: {{ w.filters_json }}{% endif %}
-            | {{ "有効" if w.enabled else "無効" }}
+            &middot; <span class="badge" style="background: {% if w.enabled %}#d1fae5; color:#059669{% else %}#f3f4f6; color:#6b7280{% endif %};">{{ "有効" if w.enabled else "無効" }}</span>
         </p>
     </div>
     <div style="display:flex; gap:0.5rem;">
@@ -49,12 +54,12 @@
             </button>
         </form>
         <form method="post" action="/watches/{{ w.id }}/run">
-            <button type="submit" style="font-size:0.8rem; padding:0.3rem 0.6rem;">実行</button>
+            <button type="submit" style="font-size:0.8rem; padding:0.3rem 0.6rem;">今すぐ実行</button>
         </form>
     </div>
 </div>
 {% endfor %}
 {% else %}
-<p class="meta">Watch がまだありません。上のフォームから追加してください。</p>
+<p class="meta">監視クエリがまだありません。上のフォームから追加してください。</p>
 {% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- ナビゲーションの英語ラベルをすべて日本語に統一
- Jinja2 フィルター（`type_label` / `status_label` / `job_type_label`）を追加し、DB値の日本語変換を一元管理
- 受信トレイ・監視クエリ・ジョブ履歴・分析・ホームに機能説明を追加
- "Venue:" "Abstract" "References/Cited by" 等の英語ラベルを日本語化
- 種別 badge ("paper"→"論文" 等)・ステータス値 ("new"→"新着" 等) を日本語表示に変更

テクニカルターム（arXiv, BibTeX, DOI, PDF, PageRank, OpenAlex 等）は英語のまま維持。

## Test plan
- [x] `pytest tests/ -v` — 119 passed
- [x] `black --check app/ tests/` — フォーマット OK
- [ ] `ri serve` でホーム・受信トレイ・監視クエリ・ジョブ履歴・分析ページを目視確認

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)