### PR TITLE
feat: 検索フィルターの年・会場を選択式に変更

### DIFF
--- a/app/web/server.py
+++ b/app/web/server.py
@@ -173,6 +173,18 @@ def search_page(
         results = all_results[start : start + per_page]
 
         all_tags = session.execute(select(Tag).order_by(Tag.name)).scalars().all()
+        all_years = [
+            r[0]
+            for r in session.execute(
+                select(Item.year).where(Item.year.is_not(None)).distinct().order_by(Item.year.desc())
+            ).all()
+        ]
+        all_venues = [
+            r[0]
+            for r in session.execute(
+                select(Item.venue).where(Item.venue.is_not(None)).distinct().order_by(Item.venue)
+            ).all()
+        ]
 
         return templates.TemplateResponse(
             "search.html",
@@ -185,6 +197,8 @@ def search_page(
                 "venue": venue or "",
                 "tag": tag or "",
                 "all_tags": all_tags,
+                "all_years": all_years,
+                "all_venues": all_venues,
                 "item_type": item_type or "",
                 "page": page,
                 "per_page": per_page,

--- a/app/web/templates/search.html
+++ b/app/web/templates/search.html
@@ -14,9 +14,19 @@
         <label>著者:</label>
         <input type="text" name="author" value="{{ author }}" placeholder="著者名" style="width:140px;">
         <label>年:</label>
-        <input type="text" name="year" value="{{ year }}" placeholder="2024 or 2023:2024" style="width:120px;">
+        <select name="year">
+            <option value="">すべて</option>
+            {% for y in all_years %}
+            <option value="{{ y }}" {% if year == y|string %}selected{% endif %}>{{ y }}</option>
+            {% endfor %}
+        </select>
         <label>会場:</label>
-        <input type="text" name="venue" value="{{ venue }}" placeholder="ACL" style="width:100px;">
+        <select name="venue">
+            <option value="">すべて</option>
+            {% for v in all_venues %}
+            <option value="{{ v }}" {% if venue == v %}selected{% endif %}>{{ v }}</option>
+            {% endfor %}
+        </select>
         <label>タグ:</label>
         <select name="tag">
             <option value="">すべて</option>


### PR DESCRIPTION
## Summary
- 年・会場フィルターをテキスト入力 → `<select>` に変更
- `search_page` で DB の実値（`Item.year` / `Item.venue` の distinct）を取得してテンプレートへ渡す
- 著者名はフリーテキストのまま（部分一致検索が必要なため）

## Test plan
- [x] `pytest tests/ -v` — 119 passed
- [x] `black --check` — OK
- [ ] `ri serve` で検索ページの年・会場 select が正しく表示されることを目視確認

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)