### PR TITLE
feat: 分析ページを会場ベースに変更

### DIFF
--- a/app/web/server.py
+++ b/app/web/server.py
@@ -799,35 +799,39 @@ def analytics_page(request: Request):
         items_added_by_month,
         items_by_type,
         items_by_year,
-        items_by_year_tag,
+        items_by_year_venue,
         top_authors,
-        top_tags,
+        top_venues,
     )
 
     session = get_session()
     try:
         by_year = items_by_year(session)
         by_month = items_added_by_month(session)
-        tags = top_tags(session, n=20, kinds=["topic", "venue"])
+        venues = top_venues(session, n=20)
         authors = top_authors(session, n=20)
         by_type = items_by_type(session)
 
-        # Tag trend: top 6 tags over years
-        top6_tag_names = [t["tag"] for t in top_tags(session, n=6, kinds=["topic", "venue"])]
-        year_tag_raw = items_by_year_tag(session, kinds=["topic", "venue"])
-        tag_year_counts: dict[str, dict[int, int]] = {t: {} for t in top6_tag_names}
-        for row in year_tag_raw:
-            if row["tag"] in tag_year_counts:
-                tag_year_counts[row["tag"]][row["year"]] = row["count"]
-        trend_years = sorted({row["year"] for row in year_tag_raw})
-        tag_trend = {
+        # Venue trend: top 6 venues over years
+        top6_venues = [v["venue"] for v in top_venues(session, n=6)]
+        year_venue_raw = items_by_year_venue(session)
+        venue_year_counts: dict[str, dict[int, int]] = {v: {} for v in top6_venues}
+        for row in year_venue_raw:
+            if row["venue"] in venue_year_counts:
+                venue_year_counts[row["venue"]][row["year"]] = row["count"]
+        trend_years = sorted({row["year"] for row in year_venue_raw})
+        venue_trend = {
             "years": trend_years,
-            "series": [{"tag": t, "data": [tag_year_counts[t].get(y, 0) for y in trend_years]} for t in top6_tag_names],
+            "series": [
+                {"venue": v, "data": [venue_year_counts[v].get(y, 0) for y in trend_years]} for v in top6_venues
+            ],
         }
 
         # Summary stats
         total_items = session.execute(select(func.count(Item.id)).where(Item.status == "active")).scalar()
-        total_tags = session.execute(select(func.count(Tag.id))).scalar()
+        total_venues = session.execute(
+            select(func.count(func.distinct(Item.venue))).where(Item.venue.is_not(None), Item.status == "active")
+        ).scalar()
         total_authors = session.execute(
             select(func.count(Author.id))
             .join(ItemAuthor, ItemAuthor.author_id == Author.id)
@@ -858,12 +862,12 @@ def analytics_page(request: Request):
             {
                 "request": request,
                 "total_items": total_items,
-                "total_tags": total_tags,
+                "total_venues": total_venues,
                 "total_authors": total_authors,
                 "by_year": by_year,
                 "by_month": by_month,
-                "tag_trend": tag_trend,
-                "tags": tags,
+                "venue_trend": venue_trend,
+                "venues": venues,
                 "authors": authors,
                 "by_type": by_type,
                 "cluster_data": cluster_data,

--- a/app/web/templates/analytics.html
+++ b/app/web/templates/analytics.html
@@ -17,8 +17,8 @@
         <div class="stat-label">著者数</div>
     </div>
     <div class="stat-box">
-        <div class="stat-num">{{ total_tags }}</div>
-        <div class="stat-label">タグ数</div>
+        <div class="stat-num">{{ total_venues }}</div>
+        <div class="stat-label">会場数</div>
     </div>
 </div>
 
@@ -42,20 +42,20 @@
     </div>
 </div>
 
-{# ─── Row 2: タグ年別推移 + タグ分布 ─── #}
+{# ─── Row 2: 会場年別推移 + 会場ランキング ─── #}
 <div style="display:grid; grid-template-columns:1fr 1fr; gap:1.5rem; margin-bottom:1.5rem;">
     <div class="card">
-        <h2 style="margin-bottom:1rem;">タグ年別推移（上位 {{ tag_trend.series|length }} タグ）</h2>
-        {% if tag_trend.series %}
-        <canvas id="chartTagTrend" height="260"></canvas>
+        <h2 style="margin-bottom:1rem;">会場年別推移（上位 {{ venue_trend.series|length }} 会場）</h2>
+        {% if venue_trend.series %}
+        <canvas id="chartVenueTrend" height="260"></canvas>
         {% else %}
         <p class="meta">データがありません。</p>
         {% endif %}
     </div>
     <div class="card">
-        <h2 style="margin-bottom:1rem;">上位タグ Top {{ tags|length }}</h2>
-        {% if tags %}
-        <canvas id="chartTags" height="260"></canvas>
+        <h2 style="margin-bottom:1rem;">会場ランキング Top {{ venues|length }}</h2>
+        {% if venues %}
+        <canvas id="chartVenues" height="260"></canvas>
         {% else %}
         <p class="meta">データがありません。</p>
         {% endif %}
@@ -244,15 +244,15 @@
     });
     {% endif %}
 
-    {% if tag_trend.series %}
+    {% if venue_trend.series %}
     {
-        const trend = {{ tag_trend | tojson }};
-        new Chart(document.getElementById('chartTagTrend'), {
+        const trend = {{ venue_trend | tojson }};
+        new Chart(document.getElementById('chartVenueTrend'), {
             type: 'line',
             data: {
                 labels: trend.years,
                 datasets: trend.series.map((s, i) => ({
-                    label: s.tag,
+                    label: s.venue,
                     data: s.data,
                     borderColor: PALETTE[i % PALETTE.length],
                     backgroundColor: 'transparent',
@@ -273,14 +273,14 @@
     }
     {% endif %}
 
-    {% if tags %}
-    new Chart(document.getElementById('chartTags'), {
+    {% if venues %}
+    new Chart(document.getElementById('chartVenues'), {
         type: 'bar',
         data: {
-            labels: {{ tags | tojson }}.map(d => d.tag),
+            labels: {{ venues | tojson }}.map(d => d.venue),
             datasets: [{
                 label: '件数',
-                data: {{ tags | tojson }}.map(d => d.count),
+                data: {{ venues | tojson }}.map(d => d.count),
                 backgroundColor: TEAL,
                 borderRadius: 3,
             }]


### PR DESCRIPTION
## Summary

- タグ年別推移 → **会場年別推移**（ACL/EMNLP/NAACL等 上位6会場の折れ線グラフ）
- 上位タグランキング → **会場ランキング**（横棒グラフ Top 20）
- サマリ統計「タグ数」→「会場数」

## Test plan

- [x] `pytest tests/ -v` → 119 passed
- [ ] `ri serve` で `/analytics` を開き会場グラフが正常表示されることを確認

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)