### PR TITLE
feat: ri import に --tags オプションを追加

### DIFF
--- a/app/cli/main.py
+++ b/app/cli/main.py
@@ -237,6 +237,7 @@ def import_cmd(
     title: Optional[str] = typer.Option(None, "--title", help="Title (for pdf/url imports)"),
     year: Optional[int] = typer.Option(None, "--year", help="Year (for pdf/url imports)"),
     item_type: str = typer.Option("blog", "--type", help="Item type for url imports"),
+    tags: Optional[str] = typer.Option(None, "--tags", help="Comma-separated tags to add (e.g. 'to-read,survey')"),
 ):
     """Import papers from various sources."""
     from app.core.db import init_db
@@ -254,6 +255,7 @@ def import_cmd(
     parsed = parse_import_spec(spec)
     src_type = parsed["type"]
     args = parsed["args"]
+    tag_list = [t.strip() for t in tags.split(",") if t.strip()] if tags else []
 
     if src_type == "acl":
         typer.echo(
@@ -270,21 +272,21 @@ def import_cmd(
 
     elif src_type == "pdf":
         typer.echo(f"Importing PDF: {args['path']}")
-        result = import_pdf(args["path"], title=title, year=year)
+        result = import_pdf(args["path"], title=title, year=year, tags=tag_list)
         typer.echo(
             f"{'Created' if result['created'] else 'Already exists'}: {result['title']} (id={result['item_id']})"
         )
 
     elif src_type == "url":
         typer.echo(f"Importing URL: {args['url']}")
-        result = import_url(args["url"], item_type=item_type, title=title, year=year)
+        result = import_url(args["url"], item_type=item_type, title=title, year=year, tags=tag_list)
         typer.echo(
             f"{'Created' if result['created'] else 'Already exists'}: {result['title']} (id={result['item_id']})"
         )
 
     elif src_type == "title":
         typer.echo(f"Searching for: {args['query']!r}")
-        result = import_by_title(args["query"])
+        result = import_by_title(args["query"], tags=tag_list)
         source_label = {"arxiv": "arXiv BibTeX", "s2": "Semantic Scholar", "placeholder": "placeholder (no match)"}.get(
             result["source"], result["source"]
         )

--- a/app/pipelines/importer.py
+++ b/app/pipelines/importer.py
@@ -115,6 +115,7 @@ def import_pdf(
     path: str | Path,
     title: str | None = None,
     year: int | None = None,
+    tags: list[str] | None = None,
     session: Session | None = None,
 ) -> dict[str, Any]:
     """Import a single PDF file.
@@ -139,6 +140,7 @@ def import_pdf(
             title=title,
             year=year,
             pdf_source=str(path),
+            tags=tags or [],
         )
         session.commit()
     except Exception:
@@ -156,6 +158,7 @@ def import_url(
     item_type: str = "blog",
     title: str | None = None,
     year: int | None = None,
+    tags: list[str] | None = None,
     session: Session | None = None,
 ) -> dict[str, Any]:
     """Import a URL (blog, slide, etc.)."""
@@ -175,6 +178,7 @@ def import_url(
             year=year,
             source_url=url,
             external_ids={"url": url},
+            tags=tags or [],
         )
         session.commit()
         item_id = item.id
@@ -286,7 +290,7 @@ def _title_score(query: str, candidate: str) -> float:
     return 0.7 * overlap / max(len(q_words), len(c_words))
 
 
-def import_by_title(query: str, session: Session | None = None) -> dict[str, Any]:
+def import_by_title(query: str, tags: list[str] | None = None, session: Session | None = None) -> dict[str, Any]:
     """Import a paper by title, resolving metadata via Semantic Scholar + arXiv.
 
     Returns: {"item_id": int, "created": bool, "title": str, "source": str}
@@ -359,6 +363,7 @@ def import_by_title(query: str, session: Session | None = None) -> dict[str, Any
                         bibtex_key=bib_key or None,
                         bibtex_raw=bibtex_raw,
                         external_ids={"arxiv": arxiv_id},
+                        tags=tags or [],
                     )
                     session.commit()
                     item_id = item.id
@@ -398,6 +403,7 @@ def import_by_title(query: str, session: Session | None = None) -> dict[str, Any
                 abstract=abstract,
                 venue=venue,
                 external_ids=external_ids,
+                tags=tags or [],
             )
             session.commit()
             item_id = item.id
@@ -406,7 +412,7 @@ def import_by_title(query: str, session: Session | None = None) -> dict[str, Any
 
         # 4. No match — import as placeholder
         logger.warning(f"No Semantic Scholar match found for title: {query!r} (best score={best_score:.2f})")
-        item, created = upsert_item(session, title=query)
+        item, created = upsert_item(session, title=query, tags=tags or [])
         session.commit()
         item_id = item.id
         item_title = item.title


### PR DESCRIPTION
## Summary

- `ri import url:... / pdf:... / title:...` でタグを登録と同時に指定できるよう対応
- `import_pdf` / `import_url` / `import_by_title` に `tags` 引数を追加
- CLI に `--tags` オプション追加（カンマ区切り）

## 使用例

\`\`\`bash
ri import url:https://arxiv.org/abs/2402.09162 --tags "to-read,survey"
ri import pdf:/path/to/paper.pdf --tags "mine,read"
ri import title:"attention is all you need" --tags "to-read"
\`\`\`

## Test plan

- [x] ruff / black パス
- [x] pytest 119件パス

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)