### PR TITLE
fix: ruff E501 行長超過を修正 (importer.py:385)

### DIFF
--- a/app/pipelines/importer.py
+++ b/app/pipelines/importer.py
@@ -382,7 +382,8 @@ def import_by_title(query: str, tags: list[str] | None = None, session: Session 
                     abstract = re.sub(r"[{}]", "", entry.get("abstract", "")).strip()
                     url = entry.get("url", f"https://aclanthology.org/{acl_id}")
                     bib_key = entry.get("ID", "")
-                    venue = normalize_venue(re.sub(r"[{}]", "", entry.get("booktitle", entry.get("journal", ""))).strip()) or None
+                    raw_venue = re.sub(r"[{}]", "", entry.get("booktitle", entry.get("journal", ""))).strip()
+                    venue = normalize_venue(raw_venue) or None
 
                     raw_lines = [f"@{etype}{{{bib_key},"]
                     for k, v in sorted(entry.items()):


### PR DESCRIPTION
## Summary

- `importer.py:385` の行長が 130 文字で ruff E501 に違反していたため、2行に分割。

## Test plan

- [ ] `ruff check app/ tests/` が通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)